### PR TITLE
Inclui textos de help no formulário de Legislação

### DIFF
--- a/bireme/leisref/tests.py
+++ b/bireme/leisref/tests.py
@@ -1,0 +1,56 @@
+from django.shortcuts import resolve_url as r
+from django.test import TestCase
+from model_mommy import mommy
+
+
+class LeisRefFormTest(TestCase):
+    def setUp(self):
+        credentials = {"username": "admin", "password": "admin"}
+        mommy.make("User", is_superuser=True, **credentials)
+        self.client.login(**credentials)
+
+    def test_help_text_in_creation_form(self):
+        mommy.make("Help", source="leisref", field="status", help_text="Help message")
+
+        response = self.client.get(r("create_legislation"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            text="""onclick="$('#help_modal_title')""",
+            count=1
+        )
+
+    def test_help_text_in_edit_form(self):
+        mommy.make("Act", id=1)
+        mommy.make("Help", source="leisref", field="denomination", help_text="Help message")
+        mommy.make("Help", source="leisref", field="fascicle_number", help_text="Help message")
+
+        response = self.client.get(r("edit_legislation", 1))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            text="""onclick="$('#help_modal_title')""",
+            count=2
+        )
+
+    def test_no_help_text_on_creation_form_when_there_is_no_help_object(self):
+        response = self.client.get(r("create_legislation"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            text="""onclick="$('#help_modal_title')"""
+        )
+
+    def test_no_help_text_on_edit_form_when_there_is_no_help_object(self):
+        mommy.make("Act", id=1)
+
+        response = self.client.get(r("edit_legislation", 1))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            text="""onclick="$('#help_modal_title')"""
+        )

--- a/bireme/templates/leisref/act_form.html
+++ b/bireme/templates/leisref/act_form.html
@@ -135,10 +135,16 @@
                                                 <span>{{ field.label }}</span>
                                           {% else %}
                                                 <label for="{{ field.auto_id }}">
+                                                    {% if field.name in help_fields %}
+                                                        <a href="#" onclick="$('#help_modal_title').html('{{ field.label }}')" data-toggle="modal" data-target="#help_modal" data-remote="/help/view/leisref/{{field.name}}/" class="field_with_help">
+                                                    {% endif %}
                                                     {% if field.field.required %}
                                                         <span class="required">{{ field.label }} <span class="mark">*</span></span>
                                                     {% else %}
                                                         {{ field.label }}
+                                                    {% endif %}
+                                                    {% if field.name in help_fields %}
+                                                        </a>
                                                     {% endif %}
                                                 </label>
                                           {% endif %}
@@ -233,10 +239,16 @@
                     {% for field in form.visible_fields %}
                         {% if field.name in indexing_fields %}
                             <label for="{{ field.auto_id }}">
+                                {% if field.name in help_fields %}
+                                    <a href="#" onclick="$('#help_modal_title').html('{{ field.label }}')" data-toggle="modal" data-target="#help_modal" data-remote="/help/view/leisref/{{field.name}}/" class="field_with_help">
+                                {% endif %}
                                 {% if field.field.required %}
                                     <span class="required">{{ field.label }} <span class="mark">*</span></span>
                                 {% else %}
                                     {{ field.label }}
+                                {% endif %}
+                                {% if field.name in help_fields %}
+                                    </a>
                                 {% endif %}
                             </label>
                             <p class="muted">{{ field.help_text }}</p>
@@ -321,6 +333,11 @@
 </div>
 
 {% include "modal_dedup.html" %}
+
+
+{% if help_fields %}
+    {% include "modal_help.html" %}
+{% endif %}
 
 {% endblock %}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+model-mommy==1.6.0


### PR DESCRIPTION
Issue: https://github.com/bireme/fi-admin/issues/874

Foi necessário modificar apenas o template do formulário.

Os testes só funcionam no nível da app `leisref`, por enquanto:

```console
python manage.py test leisref
```