### PR TITLE
Melhoria de performance no ReferenceResource reduzindo o IO em disco

### DIFF
--- a/bireme/api/bibliographic.py
+++ b/bireme/api/bibliographic.py
@@ -27,6 +27,8 @@ import json
 
 
 class ReferenceResource(CustomResource):
+    _version_cache = None
+
     class Meta:
         queryset = Reference.objects.prefetch_related('indexed_database', 'created_by', 'updated_by').all()
         allowed_methods = ['get']
@@ -157,9 +159,10 @@ class ReferenceResource(CustomResource):
             bundle.data['source_control'] = 'FONTE'
 
         # Add system version control number
-        version_file = open(os.path.join(settings.BASE_DIR, 'templates/version.txt'))
-        version_number = version_file.readlines()[0]
-        bundle.data['system_version'] = version_number.rstrip()
+        if self._version_cache is None:
+            with open(os.path.join(settings.BASE_DIR, 'templates/version.txt')) as f:
+                self._version_cache = f.readlines()[0].rstrip()
+        bundle.data['system_version'] = self._version_cache
 
         return bundle
 


### PR DESCRIPTION
Cacheado o conteúdo da versão disponível em arquivo no disco passando de O(n) para O(1).